### PR TITLE
Allow JSON specified hotspot function handlers

### DIFF
--- a/src/standalone/standalone.js
+++ b/src/standalone/standalone.js
@@ -77,6 +77,18 @@ function parseURLParameters() {
                 if (configFromURL.hasOwnProperty(key)) {
                     continue;
                 }
+                
+                // Handle function handlers in hotspots
+                if(key === "hotSpots") {
+                    responseMap[key].forEach((arr) => {
+                        for (var hkey in arr) {
+                            if(hkey.endsWith("Func")) {
+                                arr[hkey] = window[arr[hkey]];
+                            }
+                        }
+                    });
+                }
+                
                 configFromURL[key] = responseMap[key];
             }
 


### PR DESCRIPTION
Fixes issue mentioned here: https://github.com/mpetroff/pannellum/issues/252#issuecomment-281464915

Currently there is no way to specify `createTooltipFunc` or 'clickHandlerFunc` in the JSON config file, as the strings passed in are not recognised as functions, so calls to them fail.

This patch fixes the issue by explicitly searching the contents of the JSON `hotSpots` item for anything ending in `Func` and replacing the string with the relevant JS function reference. Arguments can be passed using 'createTooltipArgs` or `clickHandlerArgs` in the normal way.

NB - The JS file containing these functions must be included prior to the inclusion of standalone.js  or it won't work.